### PR TITLE
add 1305 search by ICN support

### DIFF
--- a/master-patient-index-client/pom.xml
+++ b/master-patient-index-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.6</version>
+    <version>8.0.14</version>
     <relativePath/>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Creators.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Creators.java
@@ -6,6 +6,7 @@ import org.hl7.v3.CS;
 import org.hl7.v3.ST;
 import org.hl7.v3.TEL;
 
+/** Utility class of methods used by request object creators. */
 @UtilityClass
 public final class Creators {
   /** Return a CE with the given code or null if code is null. */

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MasterPatientIndexClient.java
@@ -6,5 +6,7 @@ import org.hl7.v3.PRPAIN201310UV02;
 public interface MasterPatientIndexClient {
   PRPAIN201306UV02 request1305ByAttributes(Mpi1305RequestAttributes attributes);
 
+  PRPAIN201306UV02 request1305ByIcn(String icn);
+
   PRPAIN201310UV02 request1309ByIcn(String icn);
 }

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MasterPatientIndexClient.java
@@ -3,6 +3,7 @@ package gov.va.api.lighthouse.mpi;
 import org.hl7.v3.PRPAIN201306UV02;
 import org.hl7.v3.PRPAIN201310UV02;
 
+/** MPI Client interface. */
 public interface MasterPatientIndexClient {
   PRPAIN201306UV02 request1305ByAttributes(Mpi1305RequestAttributes attributes);
 

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305Creator.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305Creator.java
@@ -60,6 +60,8 @@ public class Mpi1305Creator {
 
   Mpi1305RequestAttributes attributes;
 
+  String icn;
+
   JAXBElement<MCCIMT000100UV01Agent> asAgent() {
     return new JAXBElement<>(
         new QName("urn:hl7-org:v3", "asAgent"),
@@ -268,6 +270,10 @@ public class Mpi1305Creator {
                     .semanticsText(stWithContent("LivingSubject.administrativeGender"))
                     .build()));
       }
+    }
+
+    if (icn != null) {
+      paramBuilder.id(II.iIBuilder().root("2.16.840.1.113883.4.349").extension(icn).build());
     }
     return paramBuilder.build();
   }

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305Creator.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305Creator.java
@@ -47,6 +47,7 @@ import org.hl7.v3.QUQIMT021001UV01DataEnterer;
 import org.hl7.v3.TS;
 import org.hl7.v3.XActMoodIntentEvent;
 
+/** 1305 request object creator. */
 @Value
 @Builder
 public class Mpi1305Creator {

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305RequestAttributes.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1305RequestAttributes.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
+/** 1305 request by attributes request body model. */
 @Value
 @Builder
 @Accessors(fluent = false)

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1309Creator.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/Mpi1309Creator.java
@@ -36,6 +36,7 @@ import org.hl7.v3.ST;
 import org.hl7.v3.TS;
 import org.hl7.v3.XActMoodIntentEvent;
 
+/** 1309 request object creator. */
 @Value
 @Builder
 public class Mpi1309Creator {

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
@@ -9,6 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+/** Configurations for MPI service. */
 @Configuration
 @EnableConfigurationProperties
 @ConfigurationProperties("mpi")

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/PatientIdTransformer.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/PatientIdTransformer.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import org.hl7.v3.II;
 import org.hl7.v3.PRPAIN201306UV02;
 
+/** Patient ID Transformer. */
 @Builder
 public class PatientIdTransformer {
   PRPAIN201306UV02 mpi;

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/PatientIdentifierSegment.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/PatientIdentifierSegment.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
+/** Patient Identifier Segment. */
 @Value
 @Builder
 public class PatientIdentifierSegment {

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
@@ -138,11 +138,19 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
     }
   }
 
-  /** Make a 1305 request. */
+  /** Make a 1305 request by attributes. */
   @Override
   public PRPAIN201306UV02 request1305ByAttributes(Mpi1305RequestAttributes attributes) {
     PRPAIN201305UV02 mvi1305RequestBody =
         Mpi1305Creator.builder().config(config).attributes(attributes).build().asSoapRequest();
+    return port().prpaIN201305UV02(mvi1305RequestBody);
+  }
+
+  /** Make a 1305 request by ICN. */
+  @Override
+  public PRPAIN201306UV02 request1305ByIcn(String icn) {
+    PRPAIN201305UV02 mvi1305RequestBody =
+        Mpi1305Creator.builder().config(config).icn(icn).build().asSoapRequest();
     return port().prpaIN201305UV02(mvi1305RequestBody);
   }
 

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
@@ -30,6 +30,7 @@ import org.hl7.v3.PRPAIN201309UV02;
 import org.hl7.v3.PRPAIN201310UV02;
 import org.springframework.util.ResourceUtils;
 
+/** Master Patient Index service SOAP client. */
 @Getter
 @Slf4j
 public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {

--- a/master-patient-index-model/pom.xml
+++ b/master-patient-index-model/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>api-starter</artifactId>
-    <version>8.0.6</version>
+    <version>8.0.14</version>
     <relativePath/>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>gov.va.api.health</groupId>
     <artifactId>health-apis-parent</artifactId>
-    <version>8.0.6</version>
+    <version>8.0.14</version>
     <relativePath/>
   </parent>
   <groupId>gov.va.api.lighthouse</groupId>


### PR DESCRIPTION
Related story: https://vajira.max.gov/browse/API-7728
Adds optional ICN field to 1305 creator, if not null, add to 1305 request message.
Creates a request by ICN method to be used by experience API(s).