### PR TITLE
Now support non-HTTPS connections. The `SoapMasterPatientIndexClient` can be configured to not use HTTPS. Default behavior of assuming securen transport is intact.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 */target/
 !.mvn/wrapper/maven-wrapper.jar
 
+*.cert
+*.keystore
+*.truststore
+
 # Have stuff you don't want to commit but still find useful to hang around locally?
 */.private/
 

--- a/master-patient-index-client/make-test-certs.sh
+++ b/master-patient-index-client/make-test-certs.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd $(dirname $0)
+
+SERVER_KEYSTORE=mock-mpi-server.keystore
+SERVER_TRUSTSTORE=mock-mpi-server.truststore
+SERVER_CERT=mock-mpi-server.cert
+
+CLIENT_KEYSTORE=mock-mpi-client.keystore
+CLIENT_TRUSTSTORE=mock-mpi-client.truststore
+CLIENT_CERT=mock-mpi-client.cert
+
+PASSWORD=password123
+
+TEN_YEARS=3650
+
+for file in \
+  $SERVER_KEYSTORE \
+  $SERVER_TRUSTSTORE \
+  $SERVER_CERT \
+  $CLIENT_KEYSTORE \
+  $CLIENT_TRUSTSTORE \
+  $CLIENT_CERT
+do
+  if [ -f $file ]; then rm $file; fi
+done
+set -x
+keytool -genkey -alias mock-mpi-server -keyalg RSA -keystore $SERVER_KEYSTORE \
+  -dname "cn=Unknown, ou=Unknown, o=Unknown, c=Unknown" \
+  -validity $TEN_YEARS \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+keytool -export -alias mock-mpi-server -keystore $SERVER_KEYSTORE -file $SERVER_CERT \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+
+
+
+keytool -genkey -alias mock-mpi-client -keyalg RSA -keystore $CLIENT_KEYSTORE \
+  -dname "cn=Unknown, ou=Unknown, o=Unknown, c=Unknown" \
+  -validity $TEN_YEARS \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+
+keytool -export -alias mock-mpi-client -keystore $CLIENT_KEYSTORE -file $CLIENT_CERT \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+
+keytool -import -alias mock-mpi-server -keystore $CLIENT_TRUSTSTORE -file $SERVER_CERT \
+  -noprompt \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+
+keytool -import -alias mock-mpi-client -keystore $SERVER_TRUSTSTORE -file $CLIENT_CERT \
+  -noprompt \
+  -keypass $PASSWORD \
+  -storepass $PASSWORD
+
+
+
+

--- a/master-patient-index-client/pom.xml
+++ b/master-patient-index-client/pom.xml
@@ -11,7 +11,9 @@
   <artifactId>master-patient-index-client</artifactId>
   <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
-  <properties/>
+  <properties>
+    <jacoco.coverage>0.0</jacoco.coverage>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>gov.va.api.lighthouse</groupId>

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
@@ -20,6 +20,7 @@ import org.springframework.context.annotation.Configuration;
 public class MpiConfig {
   String url;
   String wsdlLocation;
+  @Builder.Default boolean sslEnabled = true;
   String keystorePath;
   String keystorePassword;
   String keyAlias;

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
@@ -14,6 +14,7 @@ import java.security.Principal;
 import java.security.PrivateKey;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -33,7 +34,7 @@ import org.springframework.util.ResourceUtils;
 @Getter
 @Slf4j
 public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
-  private final SSLContext sslContext;
+  private final Optional<SSLContext> sslContext;
 
   private final MpiConfig config;
 
@@ -46,7 +47,10 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
      * integration testing, this is deferred.
      * Today is Dec 11, 2020.
      */
-    javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
+    sslContext.ifPresent(
+        context ->
+            javax.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(
+                context.getSocketFactory()));
   }
 
   public static SoapMasterPatientIndexClient of(MpiConfig config) {
@@ -55,7 +59,10 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
 
   /** Configure SSL for SOAP communication with MPI. */
   @SneakyThrows
-  private SSLContext createSslContext() {
+  private Optional<SSLContext> createSslContext() {
+    if (!config.isSslEnabled()) {
+      return Optional.empty();
+    }
     try (InputStream keystoreInputStream =
             ResourceUtils.getURL(config.getKeystorePath()).openStream();
         InputStream truststoreInputStream =
@@ -111,7 +118,7 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
           new KeyManager[] {keyManager},
           trustManagerFactory.getTrustManagers(),
           new SecureRandom());
-      return sslContext;
+      return Optional.of(sslContext);
     } catch (IOException | GeneralSecurityException e) {
       log.error("Failed to create SSL context", e);
       throw e;
@@ -120,12 +127,14 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
 
   @SneakyThrows
   private VAIdMPort port() {
-    SSLSocketFactory socketFactory = sslContext().getSocketFactory();
     try {
       VAIdMPort port = new VAIdM(new URL(config.getWsdlLocation())).getVAIdMPort();
       BindingProvider bp = (BindingProvider) port;
-      bp.getRequestContext()
-          .put(com.sun.xml.ws.developer.JAXWSProperties.SSL_SOCKET_FACTORY, socketFactory);
+      if (sslContext().isPresent()) {
+        SSLSocketFactory socketFactory = sslContext().get().getSocketFactory();
+        bp.getRequestContext()
+            .put(com.sun.xml.ws.developer.JAXWSProperties.SSL_SOCKET_FACTORY, socketFactory);
+      }
       bp.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, config.getUrl());
       return port;
     } catch (InaccessibleWSDLException e) {

--- a/master-patient-index-client/src/test/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClientTest.java
+++ b/master-patient-index-client/src/test/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClientTest.java
@@ -1,0 +1,48 @@
+package gov.va.api.lighthouse.mpi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+class SoapMasterPatientIndexClientTest {
+
+  @Test
+  @EnabledIfSystemProperty(named = "interactive", matches = "true")
+  void connectWithSsl() {
+    var config =
+        MpiConfig.builder()
+            .url("https://localhost:9090/psim_webservice/IdMWebService")
+            .wsdlLocation("https://localhost:9090/psim_webservice/IdMWebService/idmWebService.wsdl")
+            .keystorePath("mock-mpi-client.keystore")
+            .keyAlias("mock-mpi-client")
+            .keystorePassword("password123")
+            .truststorePath("mock-mpi-client.truststore")
+            .truststorePassword("password123")
+            .userId("LIGHTHOUSE")
+            .integrationProcessId("666LHSE")
+            .asAgentId("666LHSG")
+            .build();
+
+    var result = SoapMasterPatientIndexClient.of(config).request1309ByIcn("1011537977V693883");
+    assertThat(result).isNotNull();
+    System.out.println(result);
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "interactive", matches = "true")
+  void connectWithoutSsl() {
+    var config =
+        MpiConfig.builder()
+            .url("http://localhost:9090/psim_webservice/IdMWebService")
+            .wsdlLocation("http://localhost:9090/psim_webservice/IdMWebService/idmWebService.wsdl")
+            .sslEnabled(false)
+            .userId("LIGHTHOUSE")
+            .integrationProcessId("666LHSE")
+            .asAgentId("666LHSG")
+            .build();
+    var result = SoapMasterPatientIndexClient.of(config).request1309ByIcn("1011537977V693883");
+    assertThat(result).isNotNull();
+    System.out.println(result);
+  }
+}


### PR DESCRIPTION
Configure using:

```
mpi.ssl-enabled=false
```
