### PR TITLE
API-8561-configurable-timeouts

### DIFF
--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/MpiConfig.java
@@ -22,6 +22,8 @@ public class MpiConfig {
   String url;
   String wsdlLocation;
   @Builder.Default boolean sslEnabled = true;
+  String connectionTimeout;
+  String readTimeout;
   String keystorePath;
   String keystorePassword;
   String keyAlias;

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
@@ -138,10 +138,15 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
       }
       if (config().getConnectionTimeout() != null) {
         bp.getRequestContext()
-            .put("javax.xml.ws.client.connectionTimeout", config().getConnectionTimeout());
+            .put(
+                com.sun.xml.ws.developer.JAXWSProperties.CONNECT_TIMEOUT,
+                config().getConnectionTimeout());
       }
       if (config().getReadTimeout() != null) {
-        bp.getRequestContext().put("javax.xml.ws.client.receiveTimeout", config().getReadTimeout());
+        bp.getRequestContext()
+            .put(
+                com.sun.xml.ws.developer.JAXWSProperties.REQUEST_TIMEOUT,
+                config().getReadTimeout());
       }
       bp.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, config.getUrl());
       return port;

--- a/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
+++ b/master-patient-index-client/src/main/java/gov/va/api/lighthouse/mpi/SoapMasterPatientIndexClient.java
@@ -136,6 +136,13 @@ public class SoapMasterPatientIndexClient implements MasterPatientIndexClient {
         bp.getRequestContext()
             .put(com.sun.xml.ws.developer.JAXWSProperties.SSL_SOCKET_FACTORY, socketFactory);
       }
+      if (config().getConnectionTimeout() != null) {
+        bp.getRequestContext()
+            .put("javax.xml.ws.client.connectionTimeout", config().getConnectionTimeout());
+      }
+      if (config().getReadTimeout() != null) {
+        bp.getRequestContext().put("javax.xml.ws.client.receiveTimeout", config().getReadTimeout());
+      }
       bp.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, config.getUrl());
       return port;
     } catch (InaccessibleWSDLException e) {


### PR DESCRIPTION
# [API-8561](https://vajira.max.gov/browse/API-8561)
This adds configurable timeouts to the mpi client using the mpi config. Once merged, a rebuild of charon will allow the properties to be set/used in the charon deployment-unit.